### PR TITLE
Optional argument for printing response status

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,9 @@ use crate::config;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    #[clap(name="status", long, short)]
+    pub status: bool,
+
     #[clap(name="method")]
     pub method: String,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp = send_request(method, url, body, jwt).await?;
 
-    println!("{}", resp.text().await?);
+    if args.status {
+        println!("{}", resp.status());
+    }
+
+    println!("\n{}", resp.text().await?);
 
     Ok(())
 }


### PR DESCRIPTION
I added an optional argument `status` that can be used to print out the response status.

Example:
`endpoint -s get https://jsonplaceholder.typicode.com/todos/1`
would produce the following output:
```
200 OK

{
  "userId": 1,
  "id": 1,
  "title": "delectus aut autem",
  "completed": false
}
```

I also added a new line before printing the response body for readability.