### PR TITLE
Optional argument for printing response headers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,9 @@ use crate::config;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    #[clap(name="headers", long, short='H')]
+    pub headers: bool,
+
     #[clap(name="method")]
     pub method: String,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let resp = send_request(method, url, body, jwt).await?;
 
-    println!("{}", resp.text().await?);
+    if args.headers {
+        resp.headers().iter().for_each(|(key, value)| {
+            println!("{}: {}", key, value.to_str().unwrap());
+        });
+    }
+
+    println!("\n{}", resp.text().await?);
 
     Ok(())
 }


### PR DESCRIPTION
I added an optional argument status that can be used to print out the response status.

Example:
`endpoint -H get https://jsonplaceholder.typicode.com/todos/1`
would produce the following output:
```
date: Wed, 30 Aug 2023 19:29:07 GMT
content-type: application/json; charset=utf-8
content-length: 83
connection: keep-alive
x-powered-by: Express
x-ratelimit-limit: 1000
x-ratelimit-remaining: 999
x-ratelimit-reset: 1692340554
vary: Origin, Accept-Encoding
access-control-allow-credentials: true
cache-control: max-age=43200
pragma: no-cache
expires: -1
x-content-type-options: nosniff
etag: W/"53-hfEnumeNh6YirfjyjaujcOPPT+s"
via: 1.1 vegur
cf-cache-status: HIT
age: 17106
accept-ranges: bytes
report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=QfYftteylZ6DDJf%2Bp3cQS5yeWDxdNsPEvzWGKbYIA7mryYGKbg%2FIERYK%2FYz1WOx%2Fj%2FP8Jahygp56AZ4vHrkPIYUKscL9Uee3%2F%2BF%2BSNDUld8a%2FpUFTc%2BzY1gDas%2FR2qFX2pkvqBXvPZhQZ2LqUz2b"}],"group":"cf-nel","max_age":604800}
nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
server: cloudflare
cf-ray: 7fef70d69a3c6910-FRA
alt-svc: h3=":443"; ma=86400

{
  "userId": 1,
  "id": 1,
  "title": "delectus aut autem",
  "completed": false
}
```